### PR TITLE
Add product detail modal route and toast notifications

### DIFF
--- a/frontend/app/components/customer/shop-product-card.tsx
+++ b/frontend/app/components/customer/shop-product-card.tsx
@@ -1,14 +1,26 @@
 import { Button } from "../ui/button";
+import { Link, redirect } from "react-router";
 
 export default function ShopProductCard() {
   const mockImg = "https://cdn.vuahanghieu.com/unsafe/0x900/left/top/smart/filters:quality(90)/https://admin.vuahanghieu.com/upload/product/2024/08/moc-khoa-pop-mart-labubu-macaron-green-grape-mau-xanh-la-66b094ec488c7-05082024160132.jpg";
+  const product = {
+    id: "1"
+  };
   
   return (
     <div className="border-r border-b w-full h-fit grayscale hover:grayscale-0 transition duration-300">
-      <img alt="product image" src={mockImg}/>
+      <Link to={`/shop/${product.id}`}>
+        <img 
+          alt="product image" 
+          src={mockImg}
+          className="cursor-pointer"
+        />
+      </Link>
       <div className="p-3">
         <p><span className="font-semibold text-xl">200.000</span><span className="pl-1 text-xs text-muted-foreground">VND</span></p>
-        <p className="text-sm text-muted-foreground">Labubu like no other</p>
+        <Link to={`/shop/${product.id}`}>
+          <Button variant="link" className="p-0 text-sm text-muted-foreground hover:cursor-pointer h-fit">Labubu like no other</Button>
+        </Link>
         <p className="text-muted-foreground text-xs">by Alexander Wang</p>
       </div>
     </div>

--- a/frontend/app/components/ui/dialog.tsx
+++ b/frontend/app/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200",
           className
         )}
         {...props}

--- a/frontend/app/components/ui/sonner.tsx
+++ b/frontend/app/components/ui/sonner.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -8,7 +8,9 @@ import {
 export default [
   layout("routes/layout/buyer-main-layout.tsx", [
     index("routes/buyer-index.tsx"),
-    route("/shop", "routes/shop.tsx"),
+    route("/shop", "routes/shop.tsx", [
+      route(":productID", "routes/product.tsx")
+    ]),
     route("/cart", "routes/cart.tsx")
   ]),
   layout("routes/layout/authentication-layout.tsx", [

--- a/frontend/app/routes/cart.tsx
+++ b/frontend/app/routes/cart.tsx
@@ -42,7 +42,7 @@ import {
   DialogFooter,
   DialogTitle,
   DialogTrigger,
-} from "~/components/ui/dialog"
+} from "~/components/ui/dialog";
 
 const mockImg = "https://cdn.vuahanghieu.com/unsafe/0x900/left/top/smart/filters:quality(90)/https://admin.vuahanghieu.com/upload/product/2024/08/moc-khoa-pop-mart-labubu-macaron-green-grape-mau-xanh-la-66b094ec488c7-05082024160132.jpg";
 

--- a/frontend/app/routes/layout/buyer-main-layout.tsx
+++ b/frontend/app/routes/layout/buyer-main-layout.tsx
@@ -1,12 +1,14 @@
 import { Outlet } from "react-router";
 import Footer from "~/components/footer";
 import NavBar from "~/components/nav-bar";
+import { Toaster } from "sonner";
 
 export default function BuyerMainLayout() {
   return (
     <>
       <NavBar />
       <Outlet />
+      <Toaster closeButton theme="dark" position="top-center"/>
       <Footer />
     </>
   );

--- a/frontend/app/routes/product.tsx
+++ b/frontend/app/routes/product.tsx
@@ -1,0 +1,75 @@
+import type { Route } from "./+types/product";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogClose,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { useNavigate } from "react-router";
+import { Minus, Plus } from "lucide-react";
+import { Input } from "~/components/ui/input";
+import { Button } from "~/components/ui/button";
+import { ShoppingCart } from "lucide-react";
+import { Toaster, toast } from "sonner";
+
+export default function Product({ params }: Route.ComponentProps) {
+  const product = {
+    id: "1",
+    name: "Labubu",
+    price: 1000,
+    description: "This is a very fascinating Labubu",
+    image: "https://cdn.vuahanghieu.com/unsafe/0x900/left/top/smart/filters:quality(90)/https://admin.vuahanghieu.com/upload/product/2024/08/moc-khoa-pop-mart-labubu-macaron-green-grape-mau-xanh-la-66b094ec488c7-05082024160132.jpg",
+    vendor: "Alexander Wang"
+  };
+  console.log("params.productID: ", params.productID);
+  let navigate = useNavigate();
+
+  return (
+    <Dialog 
+      open={product.id === params.productID}
+      onOpenChange={
+        (open) => {
+          if (!open) navigate("/shop");
+        }
+      }
+    >
+      <DialogContent className="flex gap-6 w-fit">
+        <img src={product.image} className="w-60 h-60 rounded-md" />
+        <div className="flex flex-col justify-between">
+          <div>
+            <h1 className="text-xl font-medium tracking-tight">{product.name}</h1>
+            <p className="text-sm text-muted-foreground">{"by " + product.vendor}</p>
+            <p className="text-sm text-muted-foreground my-3">{product.description}</p>
+            <p><span className="font-semibold text-xl">{product.price}</span><span className="pl-1 text-xs text-muted-foreground">VND</span></p>
+          </div>
+          <div className="w-full flex justify-between gap-6">
+            <div className="flex gap-3">
+              <Button size="icon" variant="outline" className="rounded-full">
+                <Minus />
+              </Button>
+              <Input type="number text-center" />
+              <Button size="icon" variant="outline" className="rounded-full">
+                <Plus />
+              </Button>
+            </div>
+            <Button 
+              onClick={() => toast.success("Item added to cart", {
+                action: {
+                  label: "Undo",
+                  onClick: () => console.log("Undo"),
+                }
+              })}
+            >
+              <ShoppingCart />
+              Add to Cart
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/app/routes/shop.tsx
+++ b/frontend/app/routes/shop.tsx
@@ -1,6 +1,7 @@
 import { ScrollArea, ScrollBar } from "~/components/ui/scroll-area";
 import ShopProductCard from "~/components/customer/shop-product-card";
 import FilterArea from "~/components/customer/shop/filter-area";
+import { Outlet } from "react-router";
 
 export default function Shop() {
   return (
@@ -31,7 +32,8 @@ export default function Shop() {
             </div>
             <ScrollBar orientation="vertical" />
           </ScrollArea>
-        </section>        
+        </section>  
+        <Outlet/>      
       </div>
     </div>  
   )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "react-hook-form": "^7.62.0",
         "react-redux": "^9.2.0",
         "react-router": "^7.7.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "use-debounce": "^10.0.6",
         "vaul": "^1.1.2",
@@ -7297,6 +7298,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "react-hook-form": "^7.62.0",
     "react-redux": "^9.2.0",
     "react-router": "^7.7.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "use-debounce": "^10.0.6",
     "vaul": "^1.1.2",


### PR DESCRIPTION
Introduces a new product detail modal route under /shop/:productID, accessible via product card links. Adds the 'sonner' toast notification library, integrates a Toaster component into the buyer layout, and updates shop and product card components for modal navigation. Also refines dialog styling and updates dependencies.